### PR TITLE
Feature: Allow using different ports for the service than for the container

### DIFF
--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -38,12 +38,15 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            {{- range $key, $val := .Values.ports }}
-            {{- if $val.enabled }}
-            - name: {{ $key | quote }}
+            {{- if .Values.ports.dns.enabled }}
+            - name: "dns"
               containerPort: 5053
-              protocol: {{ default "TCP" $val.protocol | quote }}
+              protocol: {{ default "TCP" .Values.ports.dns.protocol | quote }}
             {{- end }}
+            {{- if .Values.ports.metrics.enabled }}
+            - name: "metrics"
+              containerPort: 49312
+              protocol: "TCP"
             {{- end }}
           env:
             {{- range $i, $val := .Values.env }}

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             {{- range $key, $val := .Values.ports }}
             {{- if $val.enabled }}
             - name: {{ $key | quote }}
-              containerPort: {{ $val.port }}
+              containerPort: 5053
               protocol: {{ default "TCP" $val.protocol | quote }}
             {{- end }}
             {{- end }}

--- a/charts/cloudflared/templates/service.yaml
+++ b/charts/cloudflared/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if $val.enabled }}
     - name: {{ $key | quote }}
       port: {{ $val.port }}
-      targetPort: {{ $key | quote }}
+      targetPort: 5053
       {{- if and (eq $.Values.service.type "NodePort") $val.nodePort }}
       nodePort: {{ $val.nodePort }}
       {{- end }}

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -40,7 +40,6 @@ ports:
     enabled: false
     port: 49312
     nodePort: null
-    protocol: TCP
 
 serviceAccount:
   name: ''


### PR DESCRIPTION
AFAIK the container is only listening on port 5053, so changing the port in the service section of the `values.yaml` renders the service non-working.

With the small modifications in this PR the port for the container (`containerPort` in the deployment, `targetPort` in the service) is always `5053`, no matter which port the user sets for the dns port in the `values.yaml`.

This is working for me:
```
ports:
  dns:
    enabled: true
    port: 53
```

What do you think? Useful feature?