### PR TITLE
make services configurable separately

### DIFF
--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -1,14 +1,14 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
+{{- if contains "NodePort" .Values.service.dns.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cloudflared.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.service.dns.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.ports.dns.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.service.dns.port }}
+{{- else if contains "ClusterIP" .Values.service.dns.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudflared.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:5053 to use your application"

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -38,29 +38,20 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            {{- with .Values.ports.dns }}
-            {{- if .enabled }}
             - name: dns-udp
               containerPort: 5053
               protocol: UDP
             - name: dns-tcp
               containerPort: 5053
               protocol: TCP
-            {{- end }}
-            {{- end }}
-            {{- with .Values.ports.metrics }}
-            {{- if .enabled }}
             - name: metrics
               containerPort: 49312
               protocol: TCP
-            {{- end }}
-            {{- end }}
           env:
             {{- range $i, $val := .Values.env }}
             - name: {{ $val.name | quote }}
               value: {{ $val.value | quote }}
             {{- end }}
-          {{- if and .Values.ports.metrics .Values.ports.metrics.enabled }}
           livenessProbe:
             httpGet:
               path: /metrics
@@ -69,7 +60,6 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
-          {{- end }}
           resources: {{ if not .Values.resources -}}{}{{- end }}
             {{- if .Values.resources }}
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/cloudflared/templates/service-dns-tcp.yaml
+++ b/charts/cloudflared/templates/service-dns-tcp.yaml
@@ -1,26 +1,26 @@
-{{- if and .Values.service.enabled .Values.ports.dns.enabled -}}
+{{- if .Values.service.dns.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-dns-tcp" (include "cloudflared.fullname" .) }}
   labels:
     {{- include "cloudflared.labels" . | nindent 4 }}
-    {{- with .Values.service.labels }}
+    {{- with .Values.service.dns.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- with .Values.service.dns.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.dns.type }}
   ports:
-    {{- with .Values.ports.dns }}
+    {{- with .Values.service.dns }}
     {{- if .enabled }}
     - name: dns-tcp
       port: {{ .port }}
       targetPort: dns-tcp
-      {{- if and (eq $.Values.service.type "NodePort") .nodePort }}
+      {{- if and (eq $.Values.service.dns.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
       protocol: TCP

--- a/charts/cloudflared/templates/service-dns-udp.yaml
+++ b/charts/cloudflared/templates/service-dns-udp.yaml
@@ -1,26 +1,26 @@
-{{- if and .Values.service.enabled .Values.ports.dns.enabled -}}
+{{- if .Values.service.dns.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-dns-udp" (include "cloudflared.fullname" .) }}
   labels:
     {{- include "cloudflared.labels" . | nindent 4 }}
-    {{- with .Values.service.labels }}
+    {{- with .Values.service.dns.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- with .Values.service.dns.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.dns.type }}
   ports:
-    {{- with .Values.ports.dns }}
+    {{- with .Values.service.dns }}
     {{- if .enabled }}
     - name: dns-udp
       port: {{ .port }}
       targetPort: dns-udp
-      {{- if and (eq $.Values.service.type "NodePort") .nodePort }}
+      {{- if and (eq $.Values.service.dns.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
       protocol: UDP

--- a/charts/cloudflared/templates/service-metrics.yaml
+++ b/charts/cloudflared/templates/service-metrics.yaml
@@ -1,26 +1,26 @@
-{{- if and .Values.service.enabled .Values.ports.metrics.enabled -}}
+{{- if .Values.service.metrics.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "cloudflared.fullname" .) }}
   labels:
     {{- include "cloudflared.labels" . | nindent 4 }}
-    {{- with .Values.service.labels }}
+    {{- with .Values.service.metrics.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- with .Values.service.metrics.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.service.metrics.type }}
   ports:
-    {{- with .Values.ports.metrics }}
+    {{- with .Values.service.metrics }}
     {{- if .enabled }}
     - name: metrics
       port: {{ .port }}
       targetPort: metrics
-      {{- if and (eq $.Values.service.type "NodePort") .nodePort }}
+      {{- if and (eq $.Values.service.metrics.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
       protocol: TCP

--- a/charts/cloudflared/templates/tests/test-connection.yaml
+++ b/charts/cloudflared/templates/tests/test-connection.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.service.enabled .Values.ports.metrics.enabled -}}
+{{- if and .Values.service.metrics.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -12,6 +12,6 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "cloudflared.fullname" . }}:{{ .Values.ports.metrics.port }}']
+      args: ['{{ include "cloudflared.fullname" . }}:{{ .Values.service.metrics.port }}']
   restartPolicy: Never
 {{- end }}

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -19,26 +19,26 @@ deployment:
   labels: {}
 
 service:
-  enabled: true
-  type: ClusterIP
-  annotations: {}
-  labels: {}
+  dns:
+    enabled: true
+    type: ClusterIP
+    port: 5053
+    nodePort: null
+    annotations: {}
+    labels: {}
+  metrics:
+    enabled: false
+    type: ClusterIP
+    port: 49312
+    nodePort: null
+    annotations: {}
+    labels: {}
 
 env:
   - name: TZ
     value: UTC
   - name: TUNNEL_DNS_UPSTREAM
     value: https://1.1.1.1/dns-query,https://1.0.0.1/dns-query
-
-ports:
-  dns:
-    enabled: true
-    port: 5053
-    nodePort: null
-  metrics:
-    enabled: false
-    port: 49312
-    nodePort: null
 
 serviceAccount:
   name: ''


### PR DESCRIPTION
Hi Pascal,

two major changes:

## 1. ports on the deployment are always exposed, and metrics are always used for liveness/readiness probes

This means we get liveness/readiness probes by default, not only when enabling the metrics service (see below).

## 2. ports section in values.yaml removed and moved into sub-sections of `service`:

```
service:
  dns:
    enabled: true
    type: ClusterIP
    port: 5053
    nodePort: null
    annotations: {}
    labels: {}
  metrics:
    enabled: false
    type: ClusterIP
    port: 49312
    nodePort: null
    annotations: {}
    labels: {}
```

As we only change the ports on the services anyway, it makes sense to have this in the `service` section.

In addition, we now have two "services" defined in the values.yaml, which we can manage separately. I can use Loadbalancer for one and ClusterIP for the other.

For me this means I do not need to waste a loadbalancer IP for the metrics (that will be pulled internally in the cluster and that I mostly want for the liveness/readiness anyway). 

What do you think?

(I made the commits very granular, as it is easier to rebase or rework)