### PR TITLE
charts/cloudflared/templates/NOTES.txt: adjust Loadbalancer section to having two dns services

### DIFF
--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -6,8 +6,10 @@
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.ports.dns.port }}
+  export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp )
+  export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp )
+  echo "DNS via TCP: http://$SERVICE_IP_TCP:{{ .Values.ports.dns.port }}"
+  echo "DNS via UDP: http://$SERVICE_IP_UDP:{{ .Values.ports.dns.port }}"
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudflared.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")


### PR DESCRIPTION
This just spits out two IP:PORT combinations, one for UDP and one for TCP.

More work might be needed to adjust the other sections, i.e. `ClusterIP` and `Nodeport`.