### PR TITLE
fix cloudflared Notes.txt

### DIFF
--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -8,8 +8,8 @@
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
   export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp )
   export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp )
-  echo "DNS via TCP: $SERVICE_IP_TCP:{{ .Values.ports.dns.port }}"
-  echo "DNS via UDP: $SERVICE_IP_UDP:{{ .Values.ports.dns.port }}"
+  echo "DNS via TCP: $SERVICE_IP_TCP:{{ .Values.service.dns.port }}"
+  echo "DNS via UDP: $SERVICE_IP_UDP:{{ .Values.service.dns.port }}"
 {{- else if contains "ClusterIP" .Values.service.dns.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudflared.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -5,7 +5,7 @@
   echo $NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.dns.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
+           You can watch the status of e.g the UDP service by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}-dns-udp'
   export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "DNS via TCP: $SERVICE_IP_TCP:{{ .Values.service.dns.port }}"

--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -6,8 +6,8 @@
 {{- else if contains "LoadBalancer" .Values.service.dns.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
-  export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp )
-  export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp )
+  export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "DNS via TCP: $SERVICE_IP_TCP:{{ .Values.service.dns.port }}"
   echo "DNS via UDP: $SERVICE_IP_UDP:{{ .Values.service.dns.port }}"
 {{- else if contains "ClusterIP" .Values.service.dns.type }}

--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -2,17 +2,17 @@
 {{- if contains "NodePort" .Values.service.dns.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cloudflared.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo $NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.dns.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudflared.fullname" . }}'
   export SERVICE_IP_UDP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-udp )
   export SERVICE_IP_TCP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudflared.fullname" . }}-dns-tcp )
-  echo "DNS via TCP: http://$SERVICE_IP_TCP:{{ .Values.ports.dns.port }}"
-  echo "DNS via UDP: http://$SERVICE_IP_UDP:{{ .Values.ports.dns.port }}"
+  echo "DNS via TCP: $SERVICE_IP_TCP:{{ .Values.ports.dns.port }}"
+  echo "DNS via UDP: $SERVICE_IP_UDP:{{ .Values.ports.dns.port }}"
 {{- else if contains "ClusterIP" .Values.service.dns.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudflared.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:5053 to use your application"
+  echo "Visit 127.0.0.1:5053 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 5053:$CONTAINER_PORT
 {{- end }}


### PR DESCRIPTION
## Bugfix
- fix wrong value reference `.Values.ports.dns.port` (that is now called `.Values.service.dns.port`)

## Other changes
- remove `http://` prefix from output
- add template for `kubectl get svc` commands to only get LoadBalancer IP
- use service that is existing to wait for LoadBalancer IP