### PR TITLE
Add support for custom IP for clusterIP and LoadBalancer service types

### DIFF
--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -69,9 +69,9 @@ The following values can be used to adjust the helm chart.
 | service.enabled | bool | `true` | Create a service for exposing this chart. |
 | service.labels | object | `{}` | Additional labels for the service object. |
 | service.type | string | `"ClusterIP"` | The service type used. |
-| service.clusterIP | string | `nil` | The cluster IP used if service type is == `ClusterIP`. |
+| service.clusterIP | string | `nil` | The cluster IP used if service type is `ClusterIP`. |
 | service.loadBalancerIP | string | `nil` | LoadBalancerIP if service type is `LoadBalancer`. |
-| service.loadBalancerSourceRanges | list | `[]` | Address that are allowed when service is `LoadBalancer`. |
+| service.loadBalancerSourceRanges | list | `[]` | Address that are allowed when service type is `LoadBalancer`. |
 | serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
 
 ## Maintainers

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -69,6 +69,9 @@ The following values can be used to adjust the helm chart.
 | service.enabled | bool | `true` | Create a service for exposing this chart. |
 | service.labels | object | `{}` | Additional labels for the service object. |
 | service.type | string | `"ClusterIP"` | The service type used. |
+| service.clusterIP | string | `nil` | The cluster IP used if service type is == `ClusterIP`. |
+| service.loadBalancerIP | string | `nil` | LoadBalancerIP if service type is `LoadBalancer`. |
+| service.loadBalancerSourceRanges | list | `[]` | Address that are allowed when service is `LoadBalancer`. |
 | serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
 
 ## Maintainers

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -14,6 +14,18 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ with .Values.service.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     {{- range $key, $val := .Values.ports }}
     {{- if $val.enabled }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -14,15 +14,15 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-  {{ with .Values.service.loadBalancerSourceRanges }}
-{{ toYaml . | indent 4 }}
-{{- end }}
-  {{- end }}
+    {{ with .Values.service.loadBalancerSourceRanges }}
+    {{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
     {{ with .Values.service.loadBalancerSourceRanges }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-    {{- end }}
+  {{- end }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}


### PR DESCRIPTION
Include a support for custom IP address for the LoadBalancer and ClusterIP service types.

https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer