### PR TITLE
refactor(redis): make controller implementation more abstract

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,8 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/chart.json
 apiVersion: v2
 type: application
 name: redis
 description: A Helm chart for Redis
-version: 0.2.2
+version: 1.0.0
 # renovate: image=redis
 appVersion: "7.0.8"
 
@@ -18,3 +19,10 @@ maintainers:
   - name: pascaliske
     email: info@pascaliske.dev
     url: https://pascaliske.dev
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Controller values are now configured using `controller: {}`
+    - kind: changed
+      description: Default controller kind changed from `Deployment` to `StatefulSet`

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for Redis
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)[![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)[![AppVersion: 7.0.7](https://img.shields.io/badge/AppVersion-7.0.7-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)[![AppVersion: 7.0.8](https://img.shields.io/badge/AppVersion-7.0.8-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/redis/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/docker-library/redis>
@@ -41,25 +41,25 @@ The following values can be used to adjust the helm chart.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deployment.annotations | object | `{}` | Additional annotations for the deployment object. |
-| deployment.enabled | bool | `true` | Create a workload for this chart. |
-| deployment.kind | string | `"Deployment"` | Type of the workload object. |
-| deployment.labels | object | `{}` | Additional labels for the deployment object. |
-| deployment.replicas | int | `1` | The number of replicas. |
+| controller.annotations | object | `{}` | Additional annotations for the controller object. |
+| controller.enabled | bool | `true` | Create a workload for this chart. |
+| controller.kind | string | `"StatefulSet"` | Type of the workload object. |
+| controller.labels | object | `{}` | Additional labels for the controller object. |
+| controller.replicas | int | `1` | The number of replicas. |
 | env[0] | object | `{"name":"TZ","value":"UTC"}` | Timezone for the container. |
 | extraArgs | list | `[]` | List of extra arguments for the container. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the deployment. |
+| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the controller. |
 | image.repository | string | `"redis"` | The repository to pull the image from. |
 | image.tag | string | `.Chart.AppVersion` | The docker tag, if left empty chart's appVersion will be used. |
 | nameOverride | string | `""` |  |
 | persistentVolumeClaim.annotations | object | `{}` | Additional annotations for the persistent volume claim object. |
-| persistentVolumeClaim.create | bool | `false` | Create a new persistent volume claim object. |
+| persistentVolumeClaim.create | bool | `true` | Create a new persistent volume claim object. |
 | persistentVolumeClaim.existingPersistentVolumeClaim | string | `""` | Use an existing persistent volume claim object. |
 | persistentVolumeClaim.labels | object | `{}` | Additional labels for the persistent volume claim object. |
 | persistentVolumeClaim.mountPath | string | `"/data"` | Mount path of the persistent volume claim object. |
 | persistentVolumeClaim.storageClassName | string | `""` | Storage class name for the persistent volume claim object. |
-| ports.http.enabled | bool | `true` | Enable the port inside the `Deployment` and `Service` objects. |
+| ports.http.enabled | bool | `true` | Enable the port inside the `Controller` and `Service` objects. |
 | ports.http.nodePort | string | `nil` | The external port used if `.service.type` == `NodePort`. |
 | ports.http.port | int | `6379` | The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`. |
 | ports.http.protocol | string | `"TCP"` | The protocol used for the service. |
@@ -72,7 +72,7 @@ The following values can be used to adjust the helm chart.
 | service.loadBalancerIP | string | `""` | LoadBalancerIP if service type is `LoadBalancer`. |
 | service.loadBalancerSourceRanges | list | `[]` | Allowed addresses when service type is `LoadBalancer`. |
 | service.type | string | `"ClusterIP"` | The service type used. |
-| serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
+| serviceAccount.name | string | `""` | Specify the service account used for the controller. |
 
 ## Maintainers
 

--- a/charts/redis/templates/controller.yaml
+++ b/charts/redis/templates/controller.yaml
@@ -1,27 +1,30 @@
-{{- if .Values.deployment.enabled -}}
+{{- if .Values.controller.enabled -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ include "redis.controller.kind" . }}
 metadata:
   name: {{ include "redis.fullname" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
-    {{- with .Values.deployment.labels }}
+    {{- with .Values.controller.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.deployment.annotations }}
+  {{- with .Values.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.deployment.replicas }}
-  replicas: {{ .Values.deployment.replicas }}
+  {{- if .Values.controller.replicas }}
+  replicas: {{ .Values.controller.replicas }}
+  {{- end }}
+  {{- if eq (include "redis.controller.kind" . ) "StatefulSet" }}
+  serviceName: {{ include "redis.fullname" . }}-headless
   {{- end }}
   selector:
     matchLabels:
       {{- include "redis.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.deployment.annotations }}
+      {{- with .Values.controller.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -65,7 +68,7 @@ spec:
           {{- end }}
           {{- if eq (include "redis.persistence.enabled" . ) "true" }}
           volumeMounts:
-            - name: storage-volume
+            - name: {{ include "redis.persistence.name" . }}
               mountPath: {{ .Values.persistentVolumeClaim.mountPath }}
           {{- end }}
           livenessProbe:
@@ -83,17 +86,28 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
       {{- if eq (include "redis.persistence.enabled" . ) "true" }}
+      {{- if eq (include "redis.persistence.type" . ) "volumes" }}
       volumes:
-        - name: storage-volume
+        - name: {{ include "redis.persistence.name" . }}
           persistentVolumeClaim:
-            {{- if and .Values.persistentVolumeClaim.create (empty .Values.persistentVolumeClaim.existingPersistentVolumeClaim) }}
-            claimName: {{ printf "%s-storage" (include "redis.fullname" . ) }}
+            {{- if eq (include "redis.persistence.created" . ) "true" }}
+            claimName: {{ include "redis.persistence.name" . }}
             {{- else }}
             claimName: {{ .Values.persistentVolumeClaim.existingPersistentVolumeClaim }}
             {{- end }}
+      {{- end }}
       {{- end }}
       {{- if .Values.securityContext }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       {{- end }}
+  {{- if eq (include "redis.persistence.enabled" . ) "true" }}
+  {{- if eq (include "redis.persistence.type" . ) "volumeClaimTemplates" }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "redis.persistence.name" . }}
+      spec:
+        {{- include "redis.persistence.spec" . | nindent 8 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/redis/templates/headless-service.yaml
+++ b/charts/redis/templates/headless-service.yaml
@@ -1,0 +1,21 @@
+{{- if eq (include "redis.controller.kind" . ) "StatefulSet" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}-headless
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    {{- range $key, $val := .Values.ports }}
+    {{- if $val.enabled }}
+    - name: {{ $key | quote }}
+      port: {{ $val.port }}
+      targetPort: {{ $key | quote }}
+      protocol: {{ default "TCP" $val.protocol | quote }}
+    {{- end }}
+    {{- end }}
+  selector:
+    {{- include "redis.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/redis/templates/persistantvolumeclaim.yaml
+++ b/charts/redis/templates/persistantvolumeclaim.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.persistentVolumeClaim.create (empty .Values.persistentVolumeClaim.existingPersistentVolumeClaim) -}}
+{{- if eq (include "redis.persistence.enabled" . ) "true" -}}
+{{- if eq (include "redis.persistence.type" . ) "volumes" -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,13 +14,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  volumeMode: Filesystem
-  {{- with .Values.persistentVolumeClaim.storageClassName }}
-  storageClassName: {{ . }}
-  {{- end }}
+  {{- include "redis.persistence.spec" .  | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -4,22 +4,22 @@ image:
   # -- The docker tag, if left empty chart's appVersion will be used.
   # @default -- `.Chart.AppVersion`
   tag: ''
-  # -- The pull policy for the deployment.
+  # -- The pull policy for the controller.
   pullPolicy: IfNotPresent
 
 nameOverride: ''
 fullnameOverride: ''
 
-deployment:
+controller:
   # -- Create a workload for this chart.
   enabled: true
   # -- Type of the workload object.
-  kind: Deployment
+  kind: StatefulSet
   # -- The number of replicas.
   replicas: 1
-  # -- Additional annotations for the deployment object.
+  # -- Additional annotations for the controller object.
   annotations: {}
-  # -- Additional labels for the deployment object.
+  # -- Additional labels for the controller object.
   labels: {}
 
 service:
@@ -49,7 +49,7 @@ extraArgs: []
 
 ports:
   http:
-    # -- Enable the port inside the `Deployment` and `Service` objects.
+    # -- Enable the port inside the `Controller` and `Service` objects.
     enabled: true
     # -- The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`.
     port: 6379
@@ -60,7 +60,7 @@ ports:
 
 persistentVolumeClaim:
   # -- Create a new persistent volume claim object.
-  create: false
+  create: true
   # -- Mount path of the persistent volume claim object.
   mountPath: /data
   # -- Storage class name for the persistent volume claim object.
@@ -73,7 +73,7 @@ persistentVolumeClaim:
   labels: {}
 
 serviceAccount:
-  # -- Specify the service account used for the deployment.
+  # -- Specify the service account used for the controller.
   name: ''
 
 # -- Pod-level security attributes. More info [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context).


### PR DESCRIPTION
**💥 BREAKING CHANGES:**

- Controller values are now configured using `controller: {}` instead of `deployment: {}`
- Default controller kind changed from `Deployment` to `StatefulSet`

```diff
-deployment:
+controller:
   # -- Create a workload for this chart.
   enabled: true
   # -- Type of the workload object.
-  kind: Deployment
+  kind: StatefulSet
   # -- The number of replicas.
   replicas: 1
   # -- Additional annotations for the controller object.
   annotations: {}
   # -- Additional labels for the controller object.
   labels: {}
```

Closes #173.