### PR TITLE
refactor(fritzbox-exporter): make controller implementation more abstract

### DIFF
--- a/charts/fritzbox-exporter/Chart.yaml
+++ b/charts/fritzbox-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: fritzbox-exporter
 description: A Helm chart for fritzbox-exporter
-version: 1.1.0
+version: 2.0.0
 # renovate: image=sealife/fritzbox-exporter
 appVersion: "1.0"
 
@@ -19,3 +19,13 @@ maintainers:
   - name: pascaliske
     email: info@pascaliske.dev
     url: https://pascaliske.dev
+
+dependencies:
+  - name: base
+    version: 1.0.1
+    repository: https://charts.pascaliske.dev
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: 'Controller values are now configured using `controller: {}`'

--- a/charts/fritzbox-exporter/README.md
+++ b/charts/fritzbox-exporter/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for fritzbox-exporter
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)[![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)[![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)[![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)[![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/fritzbox-exporter/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://git.r3ktm8.de/SeaLife-Docker/fritzbox_exporter>
@@ -39,18 +39,18 @@ The following values can be used to adjust the helm chart.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deployment.annotations | object | `{}` | Additional annotations for the deployment object. |
-| deployment.enabled | bool | `true` | Create a workload for this chart. |
-| deployment.kind | string | `"Deployment"` | Type of the workload object. |
-| deployment.labels | object | `{}` | Additional labels for the deployment object. |
-| deployment.replicas | int | `1` | The number of replicas. |
+| controller.annotations | object | `{}` | Additional annotations for the controller object. |
+| controller.enabled | bool | `true` | Create a workload for this chart. |
+| controller.kind | string | `"Deployment"` | Type of the workload object. |
+| controller.labels | object | `{}` | Additional labels for the controller object. |
+| controller.replicas | int | `1` | The number of replicas. |
 | env[0] | object | `{"name":"TZ","value":"UTC"}` | Timezone for the container. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the deployment. |
+| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the controller. |
 | image.repository | string | `"sealife/fritzbox-exporter"` | The repository to pull the image from. |
 | image.tag | string | `.Chart.AppVersion` | The docker tag, if left empty chart's appVersion will be used. |
 | nameOverride | string | `""` |  |
-| ports.metrics.enabled | bool | `true` | Enable the port inside the `Deployment` and `Service` objects. |
+| ports.metrics.enabled | bool | `true` | Enable the port inside the `controller` and `Service` objects. |
 | ports.metrics.port | int | `8765` | The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`. |
 | ports.metrics.protocol | string | `"TCP"` | The protocol used for the service. |
 | resources | object | `{}` | Compute resources used by the container. More info [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). |
@@ -58,7 +58,7 @@ The following values can be used to adjust the helm chart.
 | service.enabled | bool | `true` | Create a service for exposing this chart. |
 | service.labels | object | `{}` | Additional labels for the service object. |
 | service.type | string | `"ClusterIP"` | The service type used. |
-| serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
+| serviceAccount.name | string | `""` | Specify the service account used for the controller. |
 | serviceMonitor.annotations | object | `{}` | Additional annotations for the service monitor object. |
 | serviceMonitor.enabled | bool | `true` | Create a service monitor for prometheus operator. |
 | serviceMonitor.interval | string | `"30s"` | How frequently the exporter should be scraped. |

--- a/charts/fritzbox-exporter/templates/controller.yaml
+++ b/charts/fritzbox-exporter/templates/controller.yaml
@@ -1,27 +1,30 @@
-{{- if .Values.deployment.enabled -}}
+{{- if .Values.controller.enabled -}}
 apiVersion: apps/v1
-kind: {{ .Values.deployment.kind }}
+kind: {{ include "base.controller.kind" . }}
 metadata:
   name: {{ include "fritzbox-exporter.fullname" . }}
   labels:
     {{- include "fritzbox-exporter.labels" . | nindent 4 }}
-    {{- with .Values.deployment.labels }}
+    {{- with .Values.controller.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.deployment.annotations }}
+  {{- with .Values.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.deployment.replicas }}
-  replicas: {{ .Values.deployment.replicas }}
+  {{- if .Values.controller.replicas }}
+  replicas: {{ .Values.controller.replicas }}
+  {{- end }}
+  {{- if eq (include "base.controller.kind" . ) "StatefulSet" }}
+  serviceName: {{ include "fritzbox-exporter.fullname" . }}-headless
   {{- end }}
   selector:
     matchLabels:
       {{- include "fritzbox-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.deployment.annotations }}
+      {{- with .Values.controller.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/fritzbox-exporter/values.yaml
+++ b/charts/fritzbox-exporter/values.yaml
@@ -4,22 +4,22 @@ image:
   # -- The docker tag, if left empty chart's appVersion will be used.
   # @default -- `.Chart.AppVersion`
   tag: ''
-  # -- The pull policy for the deployment.
+  # -- The pull policy for the controller.
   pullPolicy: IfNotPresent
 
 nameOverride: ''
 fullnameOverride: ''
 
-deployment:
+controller:
   # -- Create a workload for this chart.
   enabled: true
   # -- Type of the workload object.
   kind: Deployment
   # -- The number of replicas.
   replicas: 1
-  # -- Additional annotations for the deployment object.
+  # -- Additional annotations for the controller object.
   annotations: {}
-  # -- Additional labels for the deployment object.
+  # -- Additional labels for the controller object.
   labels: {}
 
 service:
@@ -51,7 +51,7 @@ env:
 
 ports:
   metrics:
-    # -- Enable the port inside the `Deployment` and `Service` objects.
+    # -- Enable the port inside the `controller` and `Service` objects.
     enabled: true
     # -- The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`.
     port: 8765
@@ -59,7 +59,7 @@ ports:
     protocol: TCP
 
 serviceAccount:
-  # -- Specify the service account used for the deployment.
+  # -- Specify the service account used for the controller.
   name: ''
 
 # -- Compute resources used by the container. More info [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).


### PR DESCRIPTION
BREAKING CHANGES:

- Controller values are now configured using `controller: {}`

Closes #184.