### PR TITLE
refactor(snapdrop): make controller implementation more abstract

### DIFF
--- a/charts/snapdrop/Chart.yaml
+++ b/charts/snapdrop/Chart.yaml
@@ -1,8 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/chart.json
 apiVersion: v2
 type: application
 name: snapdrop
 description: A Helm chart for snapdrop
-version: 0.1.0
+version: 1.0.0
 # renovate: image=ghcr.io/linuxserver/snapdrop
 appVersion: "version-724f0af5"
 
@@ -18,3 +19,13 @@ maintainers:
   - name: pascaliske
     email: info@pascaliske.dev
     url: https://pascaliske.dev
+
+dependencies:
+  - name: base
+    version: 1.0.1
+    repository: https://charts.pascaliske.dev
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: 'Controller values are now configured using `controller: {}`'

--- a/charts/snapdrop/README.md
+++ b/charts/snapdrop/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for snapdrop
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)[![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)[![AppVersion: version-724f0af5](https://img.shields.io/badge/AppVersion-version--724f0af5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)[![AppVersion: version-724f0af5](https://img.shields.io/badge/AppVersion-version--724f0af5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/snapdrop/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/linuxserver/docker-snapdrop>
@@ -47,16 +47,16 @@ The following values can be used to adjust the helm chart.
 | certificate.issuerRef.name | string | `""` | Name of the referenced certificate issuer. |
 | certificate.labels | object | `{}` | Additional labels for the certificate object. |
 | certificate.secretName | string | `""` | Name of the secret in which the certificate will be stored. Defaults to the first item in dnsNames. |
-| deployment.annotations | object | `{}` | Additional annotations for the deployment object. |
-| deployment.enabled | bool | `true` | Create a workload for this chart. |
-| deployment.kind | string | `"Deployment"` | Type of the workload object. |
-| deployment.labels | object | `{}` | Additional labels for the deployment object. |
-| deployment.replicas | int | `1` | The number of replicas. |
+| controller.annotations | object | `{}` | Additional annotations for the controller object. |
+| controller.enabled | bool | `true` | Create a workload for this chart. |
+| controller.kind | string | `"Deployment"` | Type of the workload object. |
+| controller.labels | object | `{}` | Additional labels for the controller object. |
+| controller.replicas | int | `1` | The number of replicas. |
 | env[0] | object | `{"name":"TZ","value":"UTC"}` | Timezone for the container. |
 | env[1] | object | `{"name":"PUID","value":1000}` | UID to be used at runtime inside the container. |
 | env[2] | object | `{"name":"PGID","value":1000}` | GID to be used at runtime inside the container. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the deployment. |
+| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the controller. |
 | image.repository | string | `"ghcr.io/linuxserver/snapdrop"` | The repository to pull the image from. |
 | image.tag | string | `.Chart.AppVersion` | The docker tag, if left empty chart's appVersion will be used. |
 | ingressRoute.annotations | object | `{}` | Additional annotations for the ingress route object. |
@@ -67,7 +67,7 @@ The following values can be used to adjust the helm chart.
 | ingressRoute.rule | string | `""` | [Matching rule](https://doc.traefik.io/traefik/routing/routers/#rule) for the underlying router. |
 | ingressRoute.tlsSecretName | string | `""` | Use an existing secret containing the TLS certificate. |
 | nameOverride | string | `""` |  |
-| ports.http.enabled | bool | `true` | Enable the port inside the `Deployment` and `Service` objects. |
+| ports.http.enabled | bool | `true` | Enable the port inside the `controller` and `Service` objects. |
 | ports.http.nodePort | string | `nil` | The external port used if `.service.type` == `NodePort`. |
 | ports.http.port | int | `80` | The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`. |
 | ports.http.protocol | string | `"TCP"` | The protocol used for the service. |
@@ -77,7 +77,7 @@ The following values can be used to adjust the helm chart.
 | service.enabled | bool | `true` | Create a service for exposing this chart. |
 | service.labels | object | `{}` | Additional labels for the service object. |
 | service.type | string | `"ClusterIP"` | The service type used. |
-| serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
+| serviceAccount.name | string | `""` | Specify the service account used for the controller. |
 
 ## Maintainers
 

--- a/charts/snapdrop/templates/controller.yaml
+++ b/charts/snapdrop/templates/controller.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if .Values.deployment.replicas }}
   replicas: {{ .Values.deployment.replicas }}
   {{- end }}
+  {{- if eq (include "base.controller.kind" . ) "StatefulSet" }}
+  serviceName: {{ include "snapdrop.fullname" . }}-headless
+  {{- end }}
   selector:
     matchLabels:
       {{- include "snapdrop.selectorLabels" . | nindent 6 }}

--- a/charts/snapdrop/templates/headless-service.yaml
+++ b/charts/snapdrop/templates/headless-service.yaml
@@ -1,0 +1,21 @@
+{{- if eq (include "base.controller.kind" . ) "StatefulSet" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "snapdrop.fullname" . }}-headless
+  labels:
+    {{- include "snapdrop.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    {{- range $key, $val := .Values.ports }}
+    {{- if $val.enabled }}
+    - name: {{ $key | quote }}
+      port: {{ $val.port }}
+      targetPort: {{ $key | quote }}
+      protocol: {{ default "TCP" $val.protocol | quote }}
+    {{- end }}
+    {{- end }}
+  selector:
+    {{- include "snapdrop.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/snapdrop/values.yaml
+++ b/charts/snapdrop/values.yaml
@@ -4,22 +4,22 @@ image:
   # -- The docker tag, if left empty chart's appVersion will be used.
   # @default -- `.Chart.AppVersion`
   tag: ''
-  # -- The pull policy for the deployment.
+  # -- The pull policy for the controller.
   pullPolicy: IfNotPresent
 
 nameOverride: ''
 fullnameOverride: ''
 
-deployment:
+controller:
   # -- Create a workload for this chart.
   enabled: true
   # -- Type of the workload object.
   kind: Deployment
   # -- The number of replicas.
   replicas: 1
-  # -- Additional annotations for the deployment object.
+  # -- Additional annotations for the controller object.
   annotations: {}
-  # -- Additional labels for the deployment object.
+  # -- Additional labels for the controller object.
   labels: {}
 
 service:
@@ -78,7 +78,7 @@ env:
 
 ports:
   http:
-    # -- Enable the port inside the `Deployment` and `Service` objects.
+    # -- Enable the port inside the `controller` and `Service` objects.
     enabled: true
     # -- The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`.
     port: 80
@@ -88,7 +88,7 @@ ports:
     protocol: TCP
 
 serviceAccount:
-  # -- Specify the service account used for the deployment.
+  # -- Specify the service account used for the controller.
   name: ''
 
 # -- Pod-level security attributes. More info [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context).


### PR DESCRIPTION
BREAKING CHANGES:

- Controller values are now configured using `controller: {}`

Closes #179.