### PR TITLE
refactor(traefik-errors): make controller implementation more abstract

### DIFF
--- a/charts/traefik-errors/Chart.yaml
+++ b/charts/traefik-errors/Chart.yaml
@@ -1,8 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/chart.json
 apiVersion: v2
 type: application
 name: traefik-errors
 description: A Helm chart for custom traefik error pages
-version: 2.3.0
+version: 3.0.0
 # renovate: image=ghcr.io/pascaliske/traefik-errors
 appVersion: "1.0.5"
 
@@ -17,3 +18,13 @@ maintainers:
   - name: pascaliske
     email: info@pascaliske.dev
     url: https://pascaliske.dev
+
+dependencies:
+  - name: base
+    version: 1.0.1
+    repository: https://charts.pascaliske.dev
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: 'Controller values are now configured using `controller: {}`'

--- a/charts/traefik-errors/README.md
+++ b/charts/traefik-errors/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for custom traefik error pages
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)[![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)[![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)[![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)[![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/traefik-errors/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/pascaliske/docker-traefik-errors>
@@ -47,14 +47,14 @@ The following values can be used to adjust the helm chart.
 | certificate.issuerRef.name | string | `""` | Name of the referenced certificate issuer. |
 | certificate.labels | object | `{}` | Additional labels for the certificate object. |
 | certificate.secretName | string | `""` | Name of the secret in which the certificate will be stored. Defaults to the first item in dnsNames. |
-| deployment.annotations | object | `{}` | Additional annotations for the deployment object. |
-| deployment.enabled | bool | `true` | Create a workload for this chart. |
-| deployment.kind | string | `"Deployment"` | Type of the workload object. |
-| deployment.labels | object | `{}` | Additional labels for the deployment object. |
-| deployment.replicas | int | `1` | The number of replicas. |
+| controller.annotations | object | `{}` | Additional annotations for the controller object. |
+| controller.enabled | bool | `true` | Create a workload for this chart. |
+| controller.kind | string | `"Deployment"` | Type of the workload object. |
+| controller.labels | object | `{}` | Additional labels for the controller object. |
+| controller.replicas | int | `1` | The number of replicas. |
 | env[0] | object | `{"name":"TZ","value":"UTC"}` | Timezone for the container. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the deployment. |
+| image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the controller. |
 | image.repository | string | `"ghcr.io/pascaliske/traefik-errors"` | The repository to pull the image from. |
 | image.tag | string | `.Chart.AppVersion` | The docker tag, if left empty chart's appVersion will be used. |
 | ingressRoute.annotations | object | `{}` | Additional annotations for the ingress route object. |
@@ -71,7 +71,7 @@ The following values can be used to adjust the helm chart.
 | middleware.name | string | `""` | Set explicit name of middleware, defaults to chart name. |
 | middleware.statusCodes | list | `["400-599"]` | List of error codes which result in an error page. |
 | nameOverride | string | `""` |  |
-| ports.http.enabled | bool | `true` | Enable the port inside the `Deployment` and `Service` objects. |
+| ports.http.enabled | bool | `true` | Enable the port inside the `controller` and `Service` objects. |
 | ports.http.port | int | `8080` | The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`. |
 | ports.http.protocol | string | `"TCP"` | The protocol used for the service. |
 | resources | object | `{}` | Compute resources used by the container. More info [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). |
@@ -79,7 +79,7 @@ The following values can be used to adjust the helm chart.
 | service.enabled | bool | `true` | Create a service for exposing this chart. |
 | service.labels | object | `{}` | Additional labels for the service object. |
 | service.type | string | `"ClusterIP"` | The service type used. |
-| serviceAccount.name | string | `""` | Specify the service account used for the deployment. |
+| serviceAccount.name | string | `""` | Specify the service account used for the controller. |
 | tolerations | object | `{}` | Pod-level tolerations. More info [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling). |
 
 ## Maintainers

--- a/charts/traefik-errors/templates/controller.yaml
+++ b/charts/traefik-errors/templates/controller.yaml
@@ -1,27 +1,27 @@
-{{- if .Values.deployment.enabled -}}
+{{- if .Values.controller.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "traefik-errors.fullname" . }}
   labels:
     {{- include "traefik-errors.labels" . | nindent 4 }}
-    {{- with .Values.deployment.labels }}
+    {{- with .Values.controller.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.deployment.annotations }}
+  {{- with .Values.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.deployment.replicas }}
-  replicas: {{ .Values.deployment.replicas }}
+  {{- if .Values.controller.replicas }}
+  replicas: {{ .Values.controller.replicas }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "traefik-errors.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.deployment.annotations }}
+      {{- with .Values.controller.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/traefik-errors/values.yaml
+++ b/charts/traefik-errors/values.yaml
@@ -4,22 +4,22 @@ image:
   # -- The docker tag, if left empty chart's appVersion will be used.
   # @default -- `.Chart.AppVersion`
   tag: ''
-  # -- The pull policy for the deployment.
+  # -- The pull policy for the controller.
   pullPolicy: IfNotPresent
 
 nameOverride: ''
 fullnameOverride: ''
 
-deployment:
+controller:
   # -- Create a workload for this chart.
   enabled: true
   # -- Type of the workload object.
   kind: Deployment
   # -- The number of replicas.
   replicas: 1
-  # -- Additional annotations for the deployment object.
+  # -- Additional annotations for the controller object.
   annotations: {}
-  # -- Additional labels for the deployment object.
+  # -- Additional labels for the controller object.
   labels: {}
 
 service:
@@ -87,7 +87,7 @@ env:
 
 ports:
   http:
-    # -- Enable the port inside the `Deployment` and `Service` objects.
+    # -- Enable the port inside the `controller` and `Service` objects.
     enabled: true
     # -- The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`.
     port: 8080
@@ -95,7 +95,7 @@ ports:
     protocol: TCP
 
 serviceAccount:
-  # -- Specify the service account used for the deployment.
+  # -- Specify the service account used for the controller.
   name: ''
 
 # -- Compute resources used by the container. More info [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).


### PR DESCRIPTION
BREAKING CHANGES:

- Controller values are now configured using `controller: {}`

Closes #178.