### PR TITLE
feat(prometheus): deprecate chart

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/chart.json
 apiVersion: v2
 type: application
 name: prometheus
@@ -5,6 +6,7 @@ description: A Helm chart for prometheus
 version: 1.3.7
 # renovate: image=prom/prometheus
 appVersion: "v2.42.0"
+deprecated: true
 
 home: https://charts.pascaliske.dev/charts/prometheus/
 sources:
@@ -14,7 +16,3 @@ sources:
 keywords:
   - prometheus
   - metrics
-maintainers:
-  - name: pascaliske
-    email: info@pascaliske.dev
-    url: https://pascaliske.dev

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -1,8 +1,10 @@
 # [`prometheus`](https://charts.pascaliske.dev/charts/prometheus/)
 
+> **:exclamation: This Helm Chart is deprecated!**
+
 > A Helm chart for prometheus
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)[![Version: 1.3.7](https://img.shields.io/badge/Version-1.3.7-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)[![AppVersion: v2.41.0](https://img.shields.io/badge/AppVersion-v2.41.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)[![Version: 1.3.7](https://img.shields.io/badge/Version-1.3.7-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)[![AppVersion: v2.42.0](https://img.shields.io/badge/AppVersion-v2.42.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/prometheus/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/prometheus/prometheus>
@@ -102,12 +104,6 @@ The following values can be used to adjust the helm chart.
 | serviceAccount.create | bool | `true` | Create a service account for the deployment. |
 | serviceAccount.labels | object | `{}` | Additional labels for the service account object. |
 | serviceAccount.name | string | `""` | Specify the service account name used for the deployment. |
-
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| pascaliske | <info@pascaliske.dev> | <https://pascaliske.dev> |
 
 ## License
 


### PR DESCRIPTION
It's probably better to use the [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) anyway... 😅