### PR TITLE
feat(paperless): allow multiple types of volumes for consumption, export and trash directories

### DIFF
--- a/charts/paperless/Chart.yaml
+++ b/charts/paperless/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: application
 name: paperless
 description: A Helm chart for paperless-ngx
-version: 3.0.0
+version: 4.0.0
 # renovate: image=ghcr.io/paperless-ngx/paperless-ngx
 appVersion: "1.13.0"
 
@@ -23,7 +23,7 @@ maintainers:
 
 dependencies:
   - name: base
-    version: 1.0.2
+    version: 1.1.0
     repository: https://charts.pascaliske.dev
   - name: redis
     version: 1.1.2
@@ -33,6 +33,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: 'Allow management of admin secrets through chart values.'
-    - kind: removed
-      description: 'The .Values.secret.secretKey was removed. Please use new .Values.secret.values object.'
+      description: 'Allow multiple types of volumes for consumption, export and trash directories.'
+    - kind: changed
+      description: '.Values.{consumption,export,trash}.hostPath now requires a full HostPath specification.'

--- a/charts/paperless/README.md
+++ b/charts/paperless/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for paperless-ngx
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/paperless-ngx/paperless-ngx>
@@ -47,9 +47,14 @@ The following values can be used to adjust the helm chart.
 | certificate.issuerRef.name | string | `""` | Name of the referenced certificate issuer. |
 | certificate.labels | object | `{}` | Additional labels for the certificate object. |
 | certificate.secretName | string | `""` | Name of the secret in which the certificate will be stored. Defaults to the first item in dnsNames. |
+| consumption.csi | object | `{}` | CSI storage volume for the consumption directory. Only used if type equals `csi`. |
+| consumption.emptyDir | object | `{}` | Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown. |
 | consumption.enabled | bool | `true` | Enable the volume mount of a [consumption directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders). |
-| consumption.hostPath | string | `""` | Host path of the consumption directory outside the container. |
+| consumption.hostPath | object | `{}` | Host path volume for the consumption directory. Only used if type equals `hostPath`. |
 | consumption.mountPath | string | `"/consumption"` | Mount path of the consumption directory inside the container. |
+| consumption.nfs | object | `{}` | NFS storage volume for the consumption directory. Only used if type equals `nfs`. |
+| consumption.persistentVolumeClaim | object | `{}` | PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`. |
+| consumption.type | string | `"hostPath"` | Type of the target volume for the consumption directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`. |
 | controller.annotations | object | `{}` | Additional annotations for the controller object. |
 | controller.enabled | bool | `true` | Create a workload for this chart. |
 | controller.kind | string | `"Deployment"` | Type of the workload object. |
@@ -63,9 +68,14 @@ The following values can be used to adjust the helm chart.
 | export.cronJob.schedule | string | `"0 4 * * 1"` | Schedule for automated exports. |
 | export.cronJob.successfulJobsHistoryLimit | int | `3` | The number of successful finished jobs to retain. |
 | export.cronJob.suspend | bool | `false` | Enable/disable the cron job schedule quickly. |
+| export.csi | object | `{}` | CSI storage volume for the consumption directory. Only used if type equals `csi`. |
+| export.emptyDir | object | `{}` | Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown. |
 | export.enabled | bool | `true` | Enable the volume mount of an export directory for [backups](https://docs.paperless-ngx.com/administration/#backup) using the [document exporter](https://docs.paperless-ngx.com/administration/#exporter). |
-| export.hostPath | string | `""` | Host path of the export directory outside the container. |
+| export.hostPath | object | `{}` | Host path volume for the consumption directory. Only used if type equals `hostPath`. |
 | export.mountPath | string | `"/export"` | Mount path of the export directory inside the container. |
+| export.nfs | object | `{}` | NFS storage volume for the consumption directory. Only used if type equals `nfs`. |
+| export.persistentVolumeClaim | object | `{}` | PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`. |
+| export.type | string | `"hostPath"` | Type of the target volume for the export directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the controller. |
 | image.repository | string | `"ghcr.io/paperless-ngx/paperless-ngx"` | The repository to pull the image from. |
@@ -110,9 +120,14 @@ The following values can be used to adjust the helm chart.
 | service.type | string | `"ClusterIP"` | The service type used. |
 | serviceAccount.name | string | `""` | Specify the service account used for the controller. |
 | tolerations | object | `{}` | Pod-level tolerations. More info [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling). |
+| trash.csi | object | `{}` | CSI storage volume for the consumption directory. Only used if type equals `csi`. |
+| trash.emptyDir | object | `{}` | Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown. |
 | trash.enabled | bool | `false` | Enable the volume mount of a [trash directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders). |
-| trash.hostPath | string | `""` | Host path of the trash directory outside the container. |
+| trash.hostPath | object | `{}` | Host path volume for the consumption directory. Only used if type equals `hostPath`. |
 | trash.mountPath | string | `"/trash"` | Mount path of the trash directory inside the container. |
+| trash.nfs | object | `{}` | NFS storage volume for the consumption directory. Only used if type equals `nfs`. |
+| trash.persistentVolumeClaim | object | `{}` | PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`. |
+| trash.type | string | `"hostPath"` | Type of the target volume for the trash directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`. |
 
 ## Maintainers
 

--- a/charts/paperless/templates/_helpers.tpl
+++ b/charts/paperless/templates/_helpers.tpl
@@ -62,15 +62,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Consumption host path
-*/}}
-{{- define "paperless.consumption.hostPath" -}}
-{{- if .Values.consumption.enabled }}
-{{- .Values.consumption.hostPath }}
-{{- end }}
-{{- end }}
-
-{{/*
 Consumption mount path
 */}}
 {{- define "paperless.consumption.mountPath" -}}
@@ -83,23 +74,10 @@ Consumption mount path
 Consumption enabled
 */}}
 {{- define "paperless.consumption.enabled" -}}
-{{- if .Values.consumption.enabled }}
-{{- if and (include "paperless.consumption.hostPath" .) (include "paperless.consumption.mountPath" .) }}
+{{- if and .Values.consumption.enabled (include "paperless.consumption.mountPath" . ) -}}
 {{- printf "true" }}
 {{- else }}
 {{- printf "false" }}
-{{- end }}
-{{- else }}
-{{- printf "false" }}
-{{- end }}
-{{- end }}
-
-{{/*
-Export host path
-*/}}
-{{- define "paperless.export.hostPath" -}}
-{{- if .Values.export.enabled }}
-{{- .Values.export.hostPath }}
 {{- end }}
 {{- end }}
 
@@ -116,12 +94,8 @@ Export mount path
 Export enabled
 */}}
 {{- define "paperless.export.enabled" -}}
-{{- if .Values.export.enabled }}
-{{- if and (include "paperless.export.hostPath" .) (include "paperless.export.mountPath" .) }}
+{{- if and .Values.export.enabled (include "paperless.export.mountPath" . ) -}}
 {{- printf "true" }}
-{{- else }}
-{{- printf "false" }}
-{{- end }}
 {{- else }}
 {{- printf "false" }}
 {{- end }}
@@ -132,15 +106,6 @@ Export command
 */}}
 {{- define "paperless.export.command" -}}
 {{ printf "kubectl exec -it -n %s deploy/%s -- document_exporter %s" .Release.Namespace (include "paperless.fullname" . ) (include "paperless.export.mountPath" . ) }}
-{{- end }}
-
-{{/*
-Trash host path
-*/}}
-{{- define "paperless.trash.hostPath" -}}
-{{- if .Values.trash.enabled }}
-{{- .Values.trash.hostPath }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -156,12 +121,8 @@ Trash mount path
 Trash enabled
 */}}
 {{- define "paperless.trash.enabled" -}}
-{{- if .Values.trash.enabled }}
-{{- if and (include "paperless.trash.hostPath" .) (include "paperless.trash.mountPath" .) }}
+{{- if and .Values.trash.enabled (include "paperless.trash.mountPath" . ) -}}
 {{- printf "true" }}
-{{- else }}
-{{- printf "false" }}
-{{- end }}
 {{- else }}
 {{- printf "false" }}
 {{- end }}

--- a/charts/paperless/templates/controller.yaml
+++ b/charts/paperless/templates/controller.yaml
@@ -125,24 +125,18 @@ spec:
             {{- else }}
             claimName: {{ .Values.persistentVolumeClaim.existingPersistentVolumeClaim }}
             {{- end }}
-        {{- if eq (include "paperless.consumption.enabled" .) "true" }}
-        - name: consumption-volume
-          hostPath:
-            type: Directory
-            path: {{ include "paperless.consumption.hostPath" . }}
-        {{- end }}
-        {{- if eq (include "paperless.export.enabled" .) "true" }}
-        - name: export-volume
-          hostPath:
-            type: Directory
-            path: {{ include "paperless.export.hostPath" . }}
-        {{- end }}
-        {{- if eq (include "paperless.trash.enabled" .) "true" }}
-        - name: trash-volume
-          hostPath:
-            type: Directory
-            path: {{ include "paperless.trash.hostPath" . }}
-        {{- end }}
+        {{- if eq (include "paperless.consumption.enabled" .) "true" -}}
+        {{- $_ := set .Values.consumption "name" "consumption-volume" -}}
+        {{- include "base.persistence.volumeSpec" .Values.consumption | nindent 8 }}
+        {{- end -}}
+        {{- if eq (include "paperless.export.enabled" .) "true" -}}
+        {{- $_ := set .Values.export "name" "export-volume" -}}
+        {{- include "base.persistence.volumeSpec" .Values.export | nindent 8 }}
+        {{- end -}}
+        {{- if eq (include "paperless.trash.enabled" .) "true" -}}
+        {{- $_ := set .Values.trash "name" "trash-volume" -}}
+        {{- include "base.persistence.volumeSpec" .Values.trash | nindent 8 }}
+        {{- end -}}
       {{- if .Values.securityContext }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}

--- a/charts/paperless/values.schema.json
+++ b/charts/paperless/values.schema.json
@@ -39,13 +39,28 @@
         "consumption": {
             "type": "object",
             "properties": {
+                "csi": {
+                    "type": "object"
+                },
+                "emptyDir": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "hostPath": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "mountPath": {
+                    "type": "string"
+                },
+                "nfs": {
+                    "type": "object"
+                },
+                "persistentVolumeClaim": {
+                    "type": "object"
+                },
+                "type": {
                     "type": "string"
                 }
             }
@@ -113,13 +128,28 @@
                         }
                     }
                 },
+                "csi": {
+                    "type": "object"
+                },
+                "emptyDir": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "hostPath": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "mountPath": {
+                    "type": "string"
+                },
+                "nfs": {
+                    "type": "object"
+                },
+                "persistentVolumeClaim": {
+                    "type": "object"
+                },
+                "type": {
                     "type": "string"
                 }
             }
@@ -308,13 +338,28 @@
         "trash": {
             "type": "object",
             "properties": {
+                "csi": {
+                    "type": "object"
+                },
+                "emptyDir": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
                 "hostPath": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "mountPath": {
+                    "type": "string"
+                },
+                "nfs": {
+                    "type": "object"
+                },
+                "persistentVolumeClaim": {
+                    "type": "object"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/charts/paperless/values.yaml
+++ b/charts/paperless/values.yaml
@@ -124,18 +124,38 @@ persistentVolumeClaim:
 consumption:
   # -- Enable the volume mount of a [consumption directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders).
   enabled: true
+  # -- Type of the target volume for the consumption directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`.
+  type: hostPath
   # -- Mount path of the consumption directory inside the container.
   mountPath: /consumption
-  # -- Host path of the consumption directory outside the container.
-  hostPath: ''
+  # -- Host path volume for the consumption directory. Only used if type equals `hostPath`.
+  hostPath: {}
+  # -- PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`.
+  persistentVolumeClaim: {}
+  # -- CSI storage volume for the consumption directory. Only used if type equals `csi`.
+  csi: {}
+  # -- NFS storage volume for the consumption directory. Only used if type equals `nfs`.
+  nfs: {}
+  # -- Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown.
+  emptyDir: {}
 
 export:
   # -- Enable the volume mount of an export directory for [backups](https://docs.paperless-ngx.com/administration/#backup) using the [document exporter](https://docs.paperless-ngx.com/administration/#exporter).
   enabled: true
+  # -- Type of the target volume for the export directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`.
+  type: hostPath
   # -- Mount path of the export directory inside the container.
   mountPath: /export
-  # -- Host path of the export directory outside the container.
-  hostPath: ''
+  # -- Host path volume for the consumption directory. Only used if type equals `hostPath`.
+  hostPath: {}
+  # -- PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`.
+  persistentVolumeClaim: {}
+  # -- CSI storage volume for the consumption directory. Only used if type equals `csi`.
+  csi: {}
+  # -- NFS storage volume for the consumption directory. Only used if type equals `nfs`.
+  nfs: {}
+  # -- Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown.
+  emptyDir: {}
   cronJob:
     # -- Create a `CronJob` object for [automated exports](https://docs.paperless-ngx.com/administration/#backup).
     enabled: false
@@ -155,10 +175,20 @@ export:
 trash:
   # -- Enable the volume mount of a [trash directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders).
   enabled: false
+  # -- Type of the target volume for the trash directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`.
+  type: hostPath
   # -- Mount path of the trash directory inside the container.
   mountPath: /trash
-  # -- Host path of the trash directory outside the container.
-  hostPath: ''
+  # -- Host path volume for the consumption directory. Only used if type equals `hostPath`.
+  hostPath: {}
+  # -- PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`.
+  persistentVolumeClaim: {}
+  # -- CSI storage volume for the consumption directory. Only used if type equals `csi`.
+  csi: {}
+  # -- NFS storage volume for the consumption directory. Only used if type equals `nfs`.
+  nfs: {}
+  # -- Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown.
+  emptyDir: {}
 
 serviceAccount:
   # -- Specify the service account used for the controller.


### PR DESCRIPTION
💥 BREAKING CHANGE:

- `.Values.{consumption,export,trash}.hostPath` now requires a full [`hostPath` / `HostPathVolumeSource` specification](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#local-temporary-directory).

Closes #226.