### PR TITLE
#265: Auto-generating PAPERLESS_REDIS ENV variable

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: library
 name: base
 description: A Helm chart for Kubernetes
-version: 1.1.1
+version: 1.2.0
 appVersion: ""
 
 home: https://charts.pascaliske.dev

--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: removed
-      description: 'Remove values schema due to issues with flux variable substitution.'
+    - kind: added
+      description: 'Added helpers for environment variables.'

--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for Kubernetes
 
-[![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ](https://charts.pascaliske.dev)[![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ](https://charts.pascaliske.dev)
+[![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ](https://charts.pascaliske.dev)[![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ](https://charts.pascaliske.dev)
 
 * <https://github.com/pascaliske/helm-charts>
 

--- a/charts/base/templates/_env.tpl
+++ b/charts/base/templates/_env.tpl
@@ -1,8 +1,8 @@
 {{- define "base.findEnvValue" -}}
-  {{- $EnvVarName := .EnvVarName}}
+  {{- $EnvVarName := .EnvVarName -}}
   {{- range .Envs -}}
     {{- if eq .name $EnvVarName -}}
       {{ .value }}
     {{- end }}
-  {{- end}}
-{{- end}}
+  {{- end }}
+{{- end }}

--- a/charts/base/templates/_helpers.tpl
+++ b/charts/base/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{- define "base.findEnvValue" -}}
+  {{- $EnvVarName := .EnvVarName}}
+  {{- range .Envs -}}
+    {{- if eq .name $EnvVarName -}}
+      {{ .value }}
+    {{- end }}
+  {{- end}}
+{{- end}}

--- a/charts/paperless/Chart.yaml
+++ b/charts/paperless/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: application
 name: paperless
 description: A Helm chart for paperless-ngx
-version: 4.0.2
+version: 4.1.0
 # renovate: image=ghcr.io/paperless-ngx/paperless-ngx
 appVersion: "1.14.5"
 
@@ -32,5 +32,5 @@ dependencies:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: removed
-      description: 'Remove values schema due to issues with flux variable substitution.'
+    - kind: added
+      description: 'Auto-generating PAPERLESS_REDIS environment variable.'

--- a/charts/paperless/Chart.yaml
+++ b/charts/paperless/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 
 dependencies:
   - name: base
-    version: 1.1.1
+    version: 1.2.0
     repository: https://charts.pascaliske.dev
   - name: redis
     version: 1.1.3

--- a/charts/paperless/README.md
+++ b/charts/paperless/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for paperless-ngx
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.14.5](https://img.shields.io/badge/AppVersion-1.14.5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.14.5](https://img.shields.io/badge/AppVersion-1.14.5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/paperless-ngx/paperless-ngx>

--- a/charts/paperless/README.md
+++ b/charts/paperless/README.md
@@ -2,7 +2,7 @@
 
 > A Helm chart for paperless-ngx
 
-[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
+[![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)[![AppVersion: 1.14.5](https://img.shields.io/badge/AppVersion-1.14.5-informational?style=flat-square) ](https://charts.pascaliske.dev/charts/paperless/)
 
 * <https://github.com/pascaliske/helm-charts>
 * <https://github.com/paperless-ngx/paperless-ngx>

--- a/charts/paperless/ci/ct-values.yaml
+++ b/charts/paperless/ci/ct-values.yaml
@@ -1,7 +1,3 @@
-env:
-  - name: PAPERLESS_REDIS
-    value: redis://redis:6379
-
 redis:
   enabled: true
   fullnameOverride: redis

--- a/charts/paperless/templates/controller.yaml
+++ b/charts/paperless/templates/controller.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.controller.enabled -}}
 {{- $redisEnvVar := include "base.findEnvValue" (dict "Envs" .Values.env "EnvVarName" "PAPERLESS_REDIS") -}}
-{{- if or (not (or .Values.redis.enabled $redisEnvVar)) (and .Values.redis.enabled $redisEnvVar)}}
-  {{- fail "Either redis.enables or the ENV variable PAPERLESS_REDIS have to be set!" -}}
-{{- end }}
+{{- if or (not (or .Values.redis.enabled $redisEnvVar)) (and .Values.redis.enabled $redisEnvVar) -}}
+  {{- fail "Either \".Values.redis.enabled\" or the environment variable \"PAPERLESS_REDIS\" have to be set!" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: {{ include "base.controller.kind" . }}
 metadata:
@@ -65,7 +65,7 @@ spec:
             - name: PAPERLESS_TRASH_DIR
               value: {{ include "paperless.trash.mountPath" . }}
             {{- end }}
-            {{- if .Values.redis.enabled}}
+            {{- if .Values.redis.enabled }}
             - name: PAPERLESS_REDIS
               value: {{ printf "redis://%s:%v" (include "redis.fullname" .Subcharts.redis) .Values.redis.ports.http.port }}
             {{- end }}

--- a/charts/paperless/templates/controller.yaml
+++ b/charts/paperless/templates/controller.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.controller.enabled -}}
+{{- $redisEnvVar := include "base.findEnvValue" (dict "Envs" .Values.env "EnvVarName" "PAPERLESS_REDIS") -}}
+{{- if or (not (or .Values.redis.enabled $redisEnvVar)) (and .Values.redis.enabled $redisEnvVar)}}
+  {{- fail "Either redis.enables or the ENV variable PAPERLESS_REDIS have to be set!" -}}
+{{- end }}
 apiVersion: apps/v1
 kind: {{ include "base.controller.kind" . }}
 metadata:
@@ -60,6 +64,10 @@ spec:
             {{- if eq (include "paperless.trash.enabled" .) "true" }}
             - name: PAPERLESS_TRASH_DIR
               value: {{ include "paperless.trash.mountPath" . }}
+            {{- end }}
+            {{- if .Values.redis.enabled}}
+            - name: PAPERLESS_REDIS
+              value: {{ printf "redis://%s-headless:%v" (include "redis.fullname" .Subcharts.redis) .Values.redis.ports.http.port }}
             {{- end }}
             {{- if or .Values.secret.create (not (empty .Values.secret.existingSecret)) }}
             {{- range $key, $val := .Values.secret.values }}

--- a/charts/paperless/templates/controller.yaml
+++ b/charts/paperless/templates/controller.yaml
@@ -67,7 +67,7 @@ spec:
             {{- end }}
             {{- if .Values.redis.enabled}}
             - name: PAPERLESS_REDIS
-              value: {{ printf "redis://%s-headless:%v" (include "redis.fullname" .Subcharts.redis) .Values.redis.ports.http.port }}
+              value: {{ printf "redis://%s:%v" (include "redis.fullname" .Subcharts.redis) .Values.redis.ports.http.port }}
             {{- end }}
             {{- if or .Values.secret.create (not (empty .Values.secret.existingSecret)) }}
             {{- range $key, $val := .Values.secret.values }}


### PR DESCRIPTION
Solves #265

I've added extra validation to check that either the redis subchart is enabled, or that the PAPERLESS_REDIS variable is manually set, but not both.

I guess the only question is if we should have the `-headless` suffix in the hostname or not. Also, should I add myself to the contributor list?

_In the meantime, back to The Sopranos..._