### PR TITLE
feat: Add option to specify media path

### DIFF
--- a/charts/paperless/README.md
+++ b/charts/paperless/README.md
@@ -55,6 +55,14 @@ The following values can be used to adjust the helm chart.
 | consumption.nfs | object | `{}` | NFS storage volume for the consumption directory. Only used if type equals `nfs`. |
 | consumption.persistentVolumeClaim | object | `{}` | PersistentVolumeClaim for the consumption directory. Only used if type equals `pvc`. |
 | consumption.type | string | `"hostPath"` | Type of the target volume for the consumption directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`. |
+| media.csi | object | `{}` | CSI storage volume for the media directory. Only used if type equals `csi`. |
+| media.emptyDir | object | `{}` | Temporary emptyDir volume for the media directory. Only used if type equals `emptyDir` or is unknown. |
+| media.enabled | bool | `true` | Enable the volume mount of a [media directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders). |
+| media.hostPath | object | `{}` | Host path volume for the media directory. Only used if type equals `hostPath`. |
+| media.mountPath | string | `"/media"` | Mount path of the media directory inside the container. |
+| media.nfs | object | `{}` | NFS storage volume for the media directory. Only used if type equals `nfs`. |
+| media.persistentVolumeClaim | object | `{}` | PersistentVolumeClaim for the media directory. Only used if type equals `pvc`. |
+| media.type | string | `"hostPath"` | Type of the target volume for the media directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`. |
 | controller.annotations | object | `{}` | Additional annotations for the controller object. |
 | controller.enabled | bool | `true` | Create a workload for this chart. |
 | controller.kind | string | `"Deployment"` | Type of the workload object. |

--- a/charts/paperless/templates/_helpers.tpl
+++ b/charts/paperless/templates/_helpers.tpl
@@ -82,6 +82,26 @@ Consumption enabled
 {{- end }}
 
 {{/*
+Media mount path
+*/}}
+{{- define "paperless.media.mountPath" -}}
+{{- if .Values.media.enabled }}
+{{- default "/media" .Values.media.mountPath }}
+{{- end }}
+{{- end }}
+
+{{/*
+Media enabled
+*/}}
+{{- define "paperless.media.enabled" -}}
+{{- if and .Values.media.enabled (include "paperless.media.mountPath" . ) -}}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Export mount path
 */}}
 {{- define "paperless.export.mountPath" -}}

--- a/charts/paperless/templates/controller.yaml
+++ b/charts/paperless/templates/controller.yaml
@@ -67,6 +67,10 @@ spec:
             - name: PAPERLESS_CONSUMPTION_DIR
               value: {{ include "paperless.consumption.mountPath" . }}
             {{- end }}
+            {{- if eq (include "paperless.media.enabled" .) "true" }}
+            - name: PAPERLESS_MEDIA_ROOT
+              value: {{ include "paperless.media.mountPath" . }}
+            {{- end }}
             {{- if eq (include "paperless.trash.enabled" .) "true" }}
             - name: PAPERLESS_TRASH_DIR
               value: {{ include "paperless.trash.mountPath" . }}
@@ -105,6 +109,10 @@ spec:
             - name: consumption-volume
               mountPath: {{ include "paperless.consumption.mountPath" . }}
             {{- end }}
+            {{- if eq (include "paperless.media.enabled" .) "true" }}
+            - name: media-volume
+              mountPath: {{ include "paperless.media.mountPath" . }}
+            {{- end }}
             {{- if eq (include "paperless.export.enabled" .) "true" }}
             - name: export-volume
               mountPath: {{ include "paperless.export.mountPath" . }}
@@ -142,6 +150,10 @@ spec:
         {{- if eq (include "paperless.consumption.enabled" .) "true" -}}
         {{- $_ := set .Values.consumption "name" "consumption-volume" -}}
         {{- include "base.persistence.volumeSpec" .Values.consumption | nindent 8 }}
+        {{- end -}}
+        {{- if eq (include "paperless.media.enabled" .) "true" -}}
+        {{- $_ := set .Values.media "name" "media-volume" -}}
+        {{- include "base.persistence.volumeSpec" .Values.media | nindent 8 }}
         {{- end -}}
         {{- if eq (include "paperless.export.enabled" .) "true" -}}
         {{- $_ := set .Values.export "name" "export-volume" -}}

--- a/charts/paperless/values.yaml
+++ b/charts/paperless/values.yaml
@@ -140,6 +140,24 @@ consumption:
   # -- Temporary emptyDir volume for the consumption directory. Only used if type equals `emptyDir` or is unknown.
   emptyDir: {}
 
+media:
+  # -- Enable the volume mount of a [media directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders).
+  enabled: true
+  # -- Type of the target volume for the media directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`.
+  type: hostPath
+  # -- Mount path of the media directory inside the container.
+  mountPath: /media
+  # -- Host path volume for the media directory. Only used if type equals `hostPath`.
+  hostPath: {}
+  # -- PersistentVolumeClaim for the media directory. Only used if type equals `pvc`.
+  persistentVolumeClaim: {}
+  # -- CSI storage volume for the media directory. Only used if type equals `csi`.
+  csi: {}
+  # -- NFS storage volume for the media directory. Only used if type equals `nfs`.
+  nfs: {}
+  # -- Temporary emptyDir volume for the media directory. Only used if type equals `emptyDir` or is unknown.
+  emptyDir: {}
+
 export:
   # -- Enable the volume mount of an export directory for [backups](https://docs.paperless-ngx.com/administration/#backup) using the [document exporter](https://docs.paperless-ngx.com/administration/#exporter).
   enabled: true

--- a/charts/paperless/values.yaml
+++ b/charts/paperless/values.yaml
@@ -142,7 +142,7 @@ consumption:
 
 media:
   # -- Enable the volume mount of a [media directory](https://docs.paperless-ngx.com/configuration/#paths-and-folders).
-  enabled: true
+  enabled: false
   # -- Type of the target volume for the media directory. Possible values are: `hostPath`, `pvc`, `csi`, `nfs`, `emptyDir`.
   type: hostPath
   # -- Mount path of the media directory inside the container.


### PR DESCRIPTION
Currently the media directory is mounted inside the pod. If one wants to access the files one has to download them one by one from the UI. With this option it is possible to store the files on a specific pv or an nfs share.