### PR TITLE
fix(redis) set protocol definition to redis instead of http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # docs
+.idea
 .cache
 docs/index.md
 docs/index.yaml

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -11,6 +11,6 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "redis.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:6379 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit redis://127.0.0.1:6379 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 6379:$CONTAINER_PORT
 {{- end }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -36,6 +36,9 @@ spec:
       nodePort: {{ $val.nodePort }}
       {{- end }}
       protocol: {{ default "TCP" $val.protocol | quote }}
+      {{- with $val.appProtocol }}
+      appProtocol: {{ . | quote }}
+      {{- end }}
     {{- end }}
     {{- end }}
   selector:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -73,7 +73,7 @@ extraArgs: []
   # - --loglevel warning
 
 ports:
-  http:
+  redis:
     # -- Enable the port inside the `Controller` and `Service` objects.
     enabled: true
     # -- The port used as internal port and cluster-wide port if `.service.type` == `ClusterIP`.
@@ -82,6 +82,8 @@ ports:
     nodePort: null
     # -- The protocol used for the service.
     protocol: TCP
+    # -- The application protocol for this port. Used as hint for implementations to offer richer behavior.
+    appProtocol: redis
 
 persistentVolumeClaim:
   # -- Create a new persistent volume claim object.


### PR DESCRIPTION
This is needed if the pod is started in a service mesh like Istio. As a workaround, you can use this definition when deploying the chart:

```yaml
ports:
  http:
    enabled: false
  redis:
    enabled: true
    port: 6379
```

