### PR TITLE
Allow to specify Redis exporter ressources or security context

### DIFF
--- a/charts/redis/templates/controller.yaml
+++ b/charts/redis/templates/controller.yaml
@@ -94,19 +94,9 @@ spec:
               containerPort: 9121
               protocol: TCP
           securityContext:
-            runAsUser: 59000
-            runAsGroup: 59000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
+            {{- toYaml .Values.redisExporter.securityContext | nindent 12 }}
           resources:
-            requests:
-              cpu: 10m
-              memory: 50Mi
-            limits:
-              cpu: 100m
-              memory: 100Mi
+            {{- toYaml .Values.redisExporter.resources | nindent 12 }}
         {{- end }}
       {{- if eq (include "base.persistence.enabled" . ) "true" }}
       {{- if eq (include "base.persistence.type" . ) "volumes" }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -62,13 +62,7 @@ redisExporter:
     tag: 'latest'
     # -- The pull policy for the exporter.
     pullPolicy: IfNotPresent
-  resources:
-    requests:
-      cpu: 10m
-      memory: 50Mi
-    limits:
-      cpu: 100m
-      memory: 100Mi
+  # -- Pod-level security attributes. More info [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context).
   securityContext:
     runAsUser: 59000
     runAsGroup: 59000
@@ -76,6 +70,14 @@ redisExporter:
     capabilities:
       drop:
         - ALL
+  # -- Compute resources used by the container. More info [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+    limits:
+      cpu: 100m
+      memory: 100Mi
 
 env:
   # -- Timezone for the container.

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -62,6 +62,20 @@ redisExporter:
     tag: 'latest'
     # -- The pull policy for the exporter.
     pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+    limits:
+      cpu: 100m
+      memory: 100Mi
+  securityContext:
+    runAsUser: 59000
+    runAsGroup: 59000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 env:
   # -- Timezone for the container.


### PR DESCRIPTION
Default ressources or security context values are hardcoded.
This value trigger an alert _Processes experience elevated CPU throttling_ on our side and we need to update this default values.